### PR TITLE
Fix spoiler game board sizes

### DIFF
--- a/griffinbot/exts/minesweeper.py
+++ b/griffinbot/exts/minesweeper.py
@@ -349,7 +349,7 @@ class Minesweeper(commands.Cog):
         # ============
         game = GameBoard(x_distance, y_distance, bombs)
         game.buttons[0][0].left_click()
-        if area <= 196:
+        if area <= 99:
             log.trace(f"Message area: {area}")
             if not dm:
                 await ctx.send(


### PR DESCRIPTION
99 tiles is the max size for spoiler games (see [here](https://canary.discord.com/channels/786307729966628903/792886140117188622/803799974043189328))